### PR TITLE
Improve bad server response error handling

### DIFF
--- a/main/mashape/exceptions/ExceptionConstants.php
+++ b/main/mashape/exceptions/ExceptionConstants.php
@@ -29,5 +29,6 @@ define("EXCEPTION_NOTSUPPORTED_HTTPMETHOD", "HTTP method not supported. Only DEL
 
 define("EXCEPTION_SYSTEM_ERROR_CODE", 2000);
 define("EXCEPTION_JSONDECODE_REQUEST", "Can't deserialize the response JSON from the component. The method returned an invalid JSON value: %s");
+define("EXCEPTION_EMPTY_RESPONSE", "Can't deserialize the response JSON from the component. The method returned an empty value.");
 
 ?>

--- a/main/mashape/http/HttpClient.php
+++ b/main/mashape/http/HttpClient.php
@@ -17,6 +17,9 @@ class HttpClient {
 		UrlUtils::prepareRequest($url, $parameters, ($httpMethod != HttpMethod::GET) ? true : false);
 		
 		$response = self::execRequest($httpMethod, $url, $parameters);
+		if (empty($response)) {
+		    throw new MashapeClientException(EXCEPTION_EMPTY_RESPONSE, EXCEPTION_SYSTEM_ERROR_CODE);
+		}
 
 		$jsonResponse = json_decode($response);
 		if (empty($jsonResponse)) {


### PR DESCRIPTION
When I was debugging my API, the client was just saying :

> Can't deserialize the response JSON from the component. The json_decode function is missing on your server or the method returned an invalid JSON value: 

The problem was that the response from the server was empty, not that `json_decode()` was missing or response badly formatted.

This patch introduces a new error for empty server response and may help API creators to debug their API.

It corrects also the message error when the response `$response` is not empty but `json_decode($response)` is empty. This can not be because `json_decode()` is missing : you redeclare it in `json/Json.php` if it is missing.
