### PR TITLE
Added Debug tracing and response->raw_headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Request/Response tracing can be enabled:
 define ("UNIREST_TRACE", "unirest_trace.txt");
 ```
 The trace file is created in the directory of the php script that was first invoked by the webserver.
+
 `WARNING` The trace file may be visible or downloadable to web site visitors. Remember to turn off tracing!
 
 License

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Request Headers as associative array or object
 Request Body associative array or object
 
 ### Response Reference
-Upon recieving a response Unirest returns the result in the form of an Object, this object should always have the same keys for each language regarding to the response details.
+Upon receiving a response Unirest returns the result in the form of an Object, this object should always have the same keys for each language regarding to the response details.
 
 `code`
 HTTP Response Status Code (Example `200`)
@@ -106,6 +106,18 @@ Parsed response body where applicable, for example JSON responses are parsed to 
 
 `raw_body`
 Un-parsed response body
+
+`raw_headers`
+All of the response's headers as a single string. The string includes newlines.
+
+### Debug Trace
+Request/Response tracing can be enabled: 
+```php
+// Enable tracing into file unirest_trace.txt
+define ("UNIREST_TRACE", "unirest_trace.txt");
+```
+The trace file is created in the directory of the php script that was first invoked by the webserver.
+`WARNING` The trace file may be visible or downloadable to web site visitors. Remember to turn off tracing!
 
 License
 ---------------

--- a/lib/Unirest/HttpResponse.php
+++ b/lib/Unirest/HttpResponse.php
@@ -5,6 +5,7 @@ class HttpResponse
 	private $raw_body;
 	private $body;
 	private $headers;
+	private $raw_headers;
 
 	/**
 	 * HttpResponse constructor
@@ -16,6 +17,7 @@ class HttpResponse
 	{
 		$this->code = $code;
 		$this->headers = $this->get_headers_from_curl_response($headers);
+		$this->raw_headers = $headers;
 		$this->raw_body = $raw_body;
 		$this->body = $raw_body;
 		$json = json_decode($raw_body);
@@ -31,6 +33,7 @@ class HttpResponse
 	 * - raw_body
 	 * - body (if the response is json-decodable)
 	 * - headers
+	 * - raw_headers
 	 * @param  [type] $property [description]
 	 * @return [type]           [description]
 	 */

--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -96,8 +96,18 @@ class Unirest
 		curl_setopt ($ch, CURLOPT_HTTPHEADER, $lowercaseHeaders);
 		curl_setopt ($ch, CURLOPT_HEADER, true);
 		curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, false);
-		
+		$trace = defined("UNIREST_TRACE");
+		if ($trace) {
+			$trace_fh = fopen(UNIREST_TRACE, 'a');
+			curl_setopt_array($ch, array(
+				CURLOPT_VERBOSE => 1,
+				CURLOPT_STDERR  => $trace_fh,
+			));
+		}
 		$response = curl_exec($ch);
+		if ($trace) {
+			fclose($trace_fh);
+		}
 		$error = curl_error($ch);
 		if ($error) {
 			throw new \Exception($error);


### PR DESCRIPTION
Hi,

I added two features, thank you for considering them for integration.

More info below.

Regards,
Larry Kluger

### Debug Tracing

When working with a new protocol, sometimes you need to see exactly what is being sent and received "on the wire." This type of "peeking" is a common development tool for network protocols. Debug trace is enabled when he calling program defines a constant `UNIREST_TRACE`. See the bottom of the updated Readme. 

### response->raw_headers

As I developed my app, which is implementing OAuth with SharePoint Online, I found that the existing `response->headers` was not sufficient since Microsoft returns two headers with the same key (the same name). Since response->headers is a hash, the second instance of the header was overwriting the first one. There was no way for me to access the first value of the header. So I added the `raw_headers` property.

It turns out that having multiple headers with the same name is legal. See the HTTP specification: http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2  But is certainly unusual. I think adding `raw_headers` is a light-weight way to enable people to deal with this corner-case.

