### PR TITLE
Added possibility to switch off SSL verify peer option using Unirest::verifyPeer #27

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -5,6 +5,11 @@
 
     class Unirest
     {
+			 /**
+			  * Verify SSL peer
+			  * @var bool
+			  */
+			public static $verifyPeer = true;
 
     		private static $socketTimeout = null;
 				private static $defaultHeaders = array();
@@ -151,7 +156,7 @@
 						curl_setopt ($ch, CURLOPT_MAXREDIRS, 10);
 						curl_setopt ($ch, CURLOPT_HTTPHEADER, $lowercaseHeaders);
 						curl_setopt ($ch, CURLOPT_HEADER, true);
-						curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, true);
+						curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, Unirest::$verifyPeer);
 						curl_setopt ($ch, CURLOPT_ENCODING, ""); // If an empty string, "", is set, a header containing all supported encoding types is sent.
 						if (Unirest::$socketTimeout != null) {
 								curl_setopt ($ch, CURLOPT_TIMEOUT, Unirest::$socketTimeout);


### PR DESCRIPTION
Allows to switch off peer verifying, should close #27
