### PR TITLE
Check if $body is traversable before recursively sanitizing

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -171,9 +171,13 @@
 
 						$ch = curl_init();
 						if ($httpMethod != HttpMethod::GET) {
-								curl_setopt ($ch, CURLOPT_CUSTOMREQUEST, $httpMethod);
-								Unirest::http_build_query_for_curl($body, $postBody);
-								curl_setopt ($ch, CURLOPT_POSTFIELDS, $postBody);
+                                curl_setopt ($ch, CURLOPT_CUSTOMREQUEST, $httpMethod);
+                                if( is_array($body) || $body instanceof Traversable ) {
+                                    Unirest::http_build_query_for_curl($body, $postBody);
+                                    curl_setopt ($ch, CURLOPT_POSTFIELDS, $postBody);
+                                } else {
+                                    curl_setopt ($ch, CURLOPT_POSTFIELDS, $body);
+                                }
 						} else if (is_array($body)) {
 								if (strpos($url,'?') !== false) {
 									$url .= "&";

--- a/test/Unirest/UnirestTest.php
+++ b/test/Unirest/UnirestTest.php
@@ -90,6 +90,19 @@ class UnirestTest extends UnitTestCase
     $this->assertEqual("thefosk", $form->nick);
   }
 
+    public function testRawPost()
+    {
+        $response = Unirest::post("http://httpbin.org/post", array( "Accept" => "application/json" ),
+            json_encode(array(
+                "author" => "Sam Sullivan"
+            )));
+
+        $this->assertEqual(200, $response->code);
+
+        $json = $response->body->json;
+        $this->assertEqual("Sam Sullivan", $json->author);
+    }
+
   public function testUpload() {
     $response = Unirest::post("http://httpbin.org/post", array( "Accept" => "application/json" ),
       array(


### PR DESCRIPTION
Fixes issue caused by bd4975c for Issue #28.
