### PR TITLE
Fix querystrings getting urlencoded twice.

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -185,7 +185,7 @@
 									$url .= "?";
 								}
 								Unirest::http_build_query_for_curl($body, $postBody);
-								$url .= http_build_query($postBody);
+								$url .= urldecode(http_build_query($postBody));
 						}
 					
 						curl_setopt ($ch, CURLOPT_URL, Unirest::encodeUrl($url));


### PR DESCRIPTION
Because http_build_query() urlencodes the result,
but it is also urlencoded once again in Unirest::encodeUrl() when
http_build_query() is called again in there
