### PR TITLE
Fixes file attachments/uploads

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -133,7 +133,7 @@ class Unirest
      * This function is useful for serializing multidimensional arrays, and avoid getting
      * the "Array to string conversion" notice
      */
-    private static function http_build_query_for_curl($arrays, &$new = array(), $prefix = null)
+    public static function http_build_query_for_curl($arrays, &$new = array(), $prefix = null)
     {
         if (is_object($arrays)) {
             $arrays = get_object_vars($arrays);
@@ -141,7 +141,7 @@ class Unirest
         
         foreach ($arrays AS $key => $value) {
             $k = isset($prefix) ? $prefix . '[' . $key . ']' : $key;
-            if (is_array($value) OR is_object($value)) {
+            if (!$value instanceof CURLFile AND (is_array($value) OR is_object($value))) {
                 Unirest::http_build_query_for_curl($value, $new, $k);
             } else {
                 $new[$k] = $value;

--- a/test/Unirest/UnirestTest.php
+++ b/test/Unirest/UnirestTest.php
@@ -203,7 +203,24 @@ class UnirestTest extends UnitTestCase
         $form = $response->body->form;
         $this->assertEqual("Mark", $form->name);
     }
-    
+
+    public function testUploadIfFilePartOfData()
+    {  
+        $response = Unirest::post("http://httpbin.org/post", array(
+            "Accept" => "application/json"
+        ), array(
+            "name" => "Mark",
+            "files[owl.gif]" => Unirest::file(dirname(__FILE__) . "/test_upload.txt")
+        ));
+        $this->assertEqual(200, $response->code);
+        
+        //$files = $response->body->files;
+        //$this->assertEqual("This is a test", $files->file);
+        
+        $form = $response->body->form;
+        $this->assertEqual("Mark", $form->name);
+    }
+   
     public function testPostMultidimensionalArray()
     {
         $response = Unirest::post("http://httpbin.org/post", array(
@@ -342,5 +359,16 @@ class UnirestTest extends UnitTestCase
         $headers    = $response->body->headers;
         $this->assertEqual("ciao", $headers->{'User-Agent'});
     }
-    
+
+    public function testHttpBuildQueryWhenCurlFile()
+    {
+      $file = Unirest::file(dirname(__FILE__) . "/test_upload.txt");
+      $body = array(
+        "to" => "mail@mailinator.com",
+        "from" => "mail@mailinator.com",
+        "file" => $file 
+      );
+      Unirest::http_build_query_for_curl($body, $postBody);
+      $this->assertEqual($postBody['file'], $file);
+    }
 }


### PR DESCRIPTION
This fixes what is a fairly significant bug on php 5.5 - File attachments do not work.

You can see the failing spec here:
https://travis-ci.org/Mashape/unirest-php/jobs/21123639

This fixes that spec and adds an additional one detailing where the bug was - in http_build_query.
