### PR TITLE
file attachments/uploads assumes always in root namespace

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -141,7 +141,7 @@ class Unirest
         
         foreach ($arrays AS $key => $value) {
             $k = isset($prefix) ? $prefix . '[' . $key . ']' : $key;
-            if (!$value instanceof CURLFile AND (is_array($value) OR is_object($value))) {
+            if (!$value instanceof \CURLFile AND (is_array($value) OR is_object($value))) {
                 Unirest::http_build_query_for_curl($value, $new, $k);
             } else {
                 $new[$k] = $value;


### PR DESCRIPTION
I found this issue recently where we are setting different namespaces to organize our files a little better. the result would be 3 seperate broken attachments from one file.  

Setting the \ fixes it for us.
