### PR TITLE
getArrayFromQuerystring URL decoding fix

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -235,8 +235,8 @@ class Unirest
         $vars  = array();
         foreach ($pairs as $pair) {
             $nv          = explode("=", $pair, 2);
-            $name        = $nv[0];
-            $value       = $nv[1];
+            $name        = urldecode($nv[0]);
+            $value       = urldecode($nv[1]);
             $vars[$name] = $value;
         }
         return $vars;


### PR DESCRIPTION
getArrayFromQuerystring was not properly decoding the name/value pairs it found in a URL, so if (for example) your URL contained "%3A", it would get double encoded to "%253A", instead of being decoded to ":" and then encoded back to "%3A" again.