### PR TITLE
Added support for relative paths

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -263,7 +263,7 @@ class Unirest
         } else {
             $scheme = (!empty($_SERVER['HTTPS'])) ? 'https://'  : 'http://';
             $host   = $_SERVER['SERVER_NAME'];
-            $path   = $backTrace[0]['file'];
+            $path   = dirname($backTrace[0]['file']) . '/' . $url;
         }
         
         $port   = (isset($url_parsed['port']) ? $url_parsed['port'] : null);


### PR DESCRIPTION
This adds support for relative paths, meaning the user can simply provide a relative URL such as `myFolder/action.php` rather than `http://www.mywebsite.com/myFolder/action.php` - this will automatically be detected as a relative path and will be resolved by the server.
