### PR TITLE
No more dev-master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,7 @@ dependencies, you can add Unirest with it.
 ```javascript
 {
   "require" : {
-    "mashape/unirest-php" : "dev-master"
-  },
-  "autoload": {
-    "psr-0": {"Unirest": "lib/"}
+    "mashape/unirest-php" : "~1.0"
   }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
     },
     "support" : {
         "email" : "support@mashape.com"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
I have a few concerns on the autoloading.

When looking at `Unirest` class it doesn't have a namespace, so I am unable to move it to psr-4 compatibility which composer is advocating. See http://seld.be/notes/psr-4-autoloading-support-in-composer

Thanks.
