### PR TITLE
Update Unirest.php

### DIFF
--- a/lib/Unirest/Unirest.php
+++ b/lib/Unirest/Unirest.php
@@ -236,7 +236,7 @@ class Unirest
         foreach ($pairs as $pair) {
             $nv          = explode("=", $pair, 2);
             $name        = $nv[0];
-            $value       = $nv[1];
+            $value       = isset($nv[1]) ? $nv[1] : '';
             $vars[$name] = $value;
         }
         return $vars;


### PR DESCRIPTION
Void notice when given querystring params miss the '=' equal. 
For example, in the following example, the call would print a Notice : 

```
Unirest::get('https://www.googleapis.com/freebase/v1/mqlread?query=[{"type":"/music/album","name":null,"artist":{"id":"/en/bob_dylan"},"limit":3}]&cursor');
```

as you see the last keyword curson has no '=' sign

```
Notice: Undefined offset: 1 in ..... Unirest/Unirest.php on line 239
```

The url  used in the example was took from a Google tutorial
https://developers.google.com/freebase/v1/mql-overview#querying-with-cursor-paging-results
