### PR TITLE
Issue with priority of headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 build
 composer.lock
 composer.phar

--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -504,7 +504,7 @@ class Request
     {
         $formattedHeaders = array();
 
-        $combinedHeaders = array_change_key_case(array_merge((array) $headers, self::$defaultHeaders));
+        $combinedHeaders = array_change_key_case(array_merge(self::$defaultHeaders, (array) $headers));
 
         foreach ($combinedHeaders as $key => $val) {
             $formattedHeaders[] = self::getHeaderString($key, $val);

--- a/tests/Unirest/RequestTest.php
+++ b/tests/Unirest/RequestTest.php
@@ -48,6 +48,12 @@ class UnirestRequestTest extends \PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('header2', $response->body->headers);
         $this->assertEquals('world', $response->body->headers->header2);
 
+        $response = Request::get('http://mockbin.com/request', ['header1' => 'Custom value']);
+
+        $this->assertEquals(200, $response->code);
+        $this->assertObjectHasAttribute('header1', $response->body->headers);
+        $this->assertEquals('Custom value', $response->body->headers->header1);
+
         Request::clearDefaultHeaders();
 
         $response = Request::get('http://mockbin.com/request');


### PR DESCRIPTION
Custom request headers should replace default headers, if provided. This PR fixes this issue.