### PR TITLE
Fix composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "autoload": {
     "psr-0": {
-      "Unirest": "src"
+      "Unirest\\": "src/",
     }
   },
   "support": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "autoload": {
     "psr-0": {
-      "Unirest\\": "src/",
+      "Unirest\\": "src/"
     }
   },
   "support": {


### PR DESCRIPTION
I noticed the Unirest/Request directory was not included when I installed the Unirest library via composer. As a result I couldn't use
```
Unirest\Request\Body::multipart( $formdata );
```
I changed the composer.json so that everything under the Unirest namespace will be installed.