### PR TITLE
Don't use CURLOPT_CUSTOMREQUEST for POSTs

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -401,7 +401,6 @@ class Request
         if ($method !== Method::GET) {
 			if ($method === Method::POST) {
 				curl_setopt(self::$handle, CURLOPT_POST, true);
-				curl_setopt(self::$handle, CURLOPT_POSTREDIR, 3); 
 			} else {
 				curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
 			}

--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -399,7 +399,12 @@ class Request
         self::$handle = curl_init();
 
         if ($method !== Method::GET) {
-            curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
+			if ($method === Method::POST) {
+				curl_setopt(self::$handle, CURLOPT_POST, true);
+				curl_setopt(self::$handle, CURLOPT_POSTREDIR, 3); 
+			} else {
+				curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
+			}
 
             curl_setopt(self::$handle, CURLOPT_POSTFIELDS, $body);
         } elseif (is_array($body)) {


### PR DESCRIPTION
I think the current usage of CURLOPT_CUSTOMREQUEST is wrong. As far as I can tell CURLOPT_CUSTOMREQUEST = Method::POST is not the same thing as CURLOPT_POST = true. 

I struggled for hours with POSTed data not being accepted by IIS. First IIS threw an HTTP 411 due to curl not sending a Content-Length header. That is solved by replacing CURLOPT_CUSTOMREQUEST with CURLOPT_POST in the case of actual POSTs. Also, IIS in my case returns an HTTP 301 redirect, which I need Unirest to follow, so I set the CURLOPT_POSTREDIR = 3 in order to let the POST follow on redirect via 301 or 302. 

Notice this: https://curl.haxx.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html - "Many people have wrongly used this option to replace the entire request with their own, including multiple headers and POST contents. While that might work in many cases, it will cause libcurl to send invalid requests and it could possibly confuse the remote server badly. Use CURLOPT_POST and CURLOPT_POSTFIELDS to set POST data. Use CURLOPT_HTTPHEADER to replace or extend the set of headers sent by libcurl. Use CURLOPT_HTTP_VERSION to change HTTP version."

In any case, I know that the CURLOPT_POSTREDIR option probably shouldn't go here and should be client configurable, but I can't find a good place for it. It would be nice to have one-shot $curlOpts passed in with the send method, or curlOpts() that otherwise live for only one curl_exec().