### PR TITLE
add curl options for HEAD requests (otherwise HEAD fails)

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -399,6 +399,9 @@ class Request
 			if ($method === Method::POST) {
 				curl_setopt(self::$handle, CURLOPT_POST, true);
 			} else {
+                 if ($method === Method::HEAD) {
+                    curl_setopt(self::$handle, CURLOPT_NOBODY, true);
+                 }
 				curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
 			}
 

--- a/tests/Unirest/RequestTest.php
+++ b/tests/Unirest/RequestTest.php
@@ -251,6 +251,16 @@ class UnirestRequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('John', $response->body->queryString->name[1]);
     }
 
+    // HEAD
+    public function testHead()
+    {
+        $response = Request::head('http://mockbin.com/request?name=Mark', array(
+          'Accept' => 'application/json'
+        ));
+
+        $this->assertEquals(200, $response->code);
+    }
+
     // POST
     public function testPost()
     {


### PR DESCRIPTION
When using HEAD requests set the appropriate curl header to not wait for a response body. See http://www.php.net/manual/en/function.curl-setopt.php on CURLOPT_NOBODY.

Otherwise, curl will only return after the default timeout is reached, or if the requesting webserver/firewall terminates the connection for being open without reason.