### PR TITLE
Removed decode, because Request::getArrayFromQuerystring uses parse_s…

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -413,7 +413,7 @@ class Request
                 $url .= '?';
             }
 
-            $url .= urldecode(http_build_query(self::buildHTTPCurlQuery($body)));
+            $url .= http_build_query(self::buildHTTPCurlQuery($body));
         }
 
         $curl_base_options = [


### PR DESCRIPTION
…tr which also decodes. This error looses the + in a query parameter.