### PR TITLE
parse_url does not return port as array, but it is used as array in R…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ composer.lock
 composer.phar
 coverage
 vendor
+
+composer

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-  "name": "mashape/unirest-php",
+  "name": "brockhaus/unirest-php",
   "description": "Unirest PHP",
   "keywords": ["rest", "curl", "http", "https", "client"],
   "type": "library",
-  "homepage": "https://github.com/Mashape/unirest-php",
+  "homepage": "https://github.com/brockhaus/unirest-php",
   "license": "MIT",
   "author": "Mashape <opensource@mashape.com> (https://www.mashape.com)",
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,7 @@
     "codeclimate/php-test-reporter": "0.1.*"
   },
   "autoload": {
-    "psr-0": {
-      "Unirest\\": "src/"
-    }
+    "psr-4": { "Unirest\\": "src/Unirest" }
   },
   "support": {
     "email": "opensource@mashape.com"

--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -555,7 +555,7 @@ class Request
             $query = '?' . http_build_query(self::getArrayFromQuerystring($query));
         }
 
-        if ($port && $port[0] !== ':') {
+        if ($port && (!is_array($port) || $port[0] !== ':')) {
             $port = ':' . $port;
         }
 


### PR DESCRIPTION
…equest.php

So I added a check, wether this is an array actually, else I use the port as intended as int. I would assume, that that array check is needless altogether but maybe old PHP versions needed that?